### PR TITLE
fix initial value of `news` to prevent errors during loading

### DIFF
--- a/app.jl
+++ b/app.jl
@@ -51,7 +51,7 @@ end
     @out period_diff = 0.0
     @out percent_return = 0.0
     @out avgval = 0.0
-    @out news = [Dict()]
+    @out news = Dict[]
     @in window = 365
     @onchange isready, start_date, end_date, selected_stock begin
         try


### PR DESCRIPTION
Currently the app throws errors in the brwoser console during loading due to undefined `newsItem.Symbols`.
This PR fixes the errors ;-)